### PR TITLE
Format the file if no changes are provided

### DIFF
--- a/bin/src/io/github/alechenninger/monarch/Main.java
+++ b/bin/src/io/github/alechenninger/monarch/Main.java
@@ -87,9 +87,7 @@ public class Main {
       Set<String> mergeKeys = options.mergeKeys();
 
       if (!changes.iterator().hasNext()) {
-        System.out.println("No changes provided; nothing to do.");
-        System.out.println(cliInputs.helpMessage());
-        return;
+        System.out.println("No changes provided; formatting target.");
       }
 
       List<String> affectedSources = hierarchy.hierarchyOf(pivotSource)


### PR DESCRIPTION
This makes it useful to run monarch against a file which hasn't been
managed with Monarch previously, so that the diffs are more meaningful.
