### PR TITLE
Use same options to refer to source/target for both apply and set

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -64,7 +64,7 @@ optional arguments:
                              environment: stage
                            set:
                              myapp::favorite_website: http://stage.redhat.com
-  --target TARGET [TARGET ...], -t TARGET [TARGET ...]
+  --target TARGET [TARGET ...], -t TARGET [TARGET ...], --source TARGET [TARGET ...], -s TARGET [TARGET ...]
                          A target is the source  in  the  source  tree  from  where you want to
                          change, including itself and any sources  beneath it in the hierarchy.
                          Redundant keys will be  removed  in  sources  beneath the target (that
@@ -150,7 +150,7 @@ optional arguments:
   -?, --help             Show this message and exit.
   --changes CHANGES, --changeset CHANGES, --change CHANGES, -c CHANGES
                          Path to a file with changes to modify or create.
-  --source SOURCE [SOURCE ...], -s SOURCE [SOURCE ...]
+  --source SOURCE [SOURCE ...], -s SOURCE [SOURCE ...], --target SOURCE [SOURCE ...], -t SOURCE [SOURCE ...]
                          Identifies the change  to  operate  on  by  its  data  source.  May be
                          defined as a single data source path,  or  as a set of key=value pairs
                          which evaluate  to  a  single  source  in  a  dynamic  hierarchy.  For

--- a/bin/src/io/github/alechenninger/monarch/ArgParseMonarchArgParser.java
+++ b/bin/src/io/github/alechenninger/monarch/ArgParseMonarchArgParser.java
@@ -274,7 +274,7 @@ public class ArgParseMonarchArgParser implements MonarchArgParser {
               "  set:\n" +
               "    myapp::favorite_website: http://stage.redhat.com");
 
-      subparser.addArgument("--target", "-t")
+      subparser.addArgument("--target", "-t", "--source", "-s")
           .dest("target")
           .required(true)
           .nargs("+")
@@ -450,7 +450,7 @@ public class ArgParseMonarchArgParser implements MonarchArgParser {
           .required(true)
           .help("Path to a file with changes to modify or create.");
 
-      subparser.addArgument("--source", "-s")
+      subparser.addArgument("--source", "-s", "--target", "-t")
           .dest("source")
           .required(true)
           .nargs("+")

--- a/generateBinReadme.sh
+++ b/generateBinReadme.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+>&2 echo "NOTE: Console width should be 100 characters wide"
+
 monarchHelp=$(monarch -?)
 applyHelp=$(monarch apply -?)
 setHelp=$(monarch set -?)


### PR DESCRIPTION
So you don't have to remember to use -t in one command and -s in another when they basically refer to the same thing