### PR TITLE
Fixes #92: Make dynamic hierarchy source lineage and descendants relative

### DIFF
--- a/bin/src/io/github/alechenninger/monarch/DataFormats.java
+++ b/bin/src/io/github/alechenninger/monarch/DataFormats.java
@@ -18,9 +18,7 @@
 
 package io.github.alechenninger.monarch;
 
-import io.github.alechenninger.monarch.yaml.YamlConfiguration;
 import io.github.alechenninger.monarch.yaml.YamlDataFormat;
-import org.yaml.snakeyaml.Yaml;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.Charset;
@@ -33,7 +31,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * Represents both a collection of known {@link DataFormat}s by capability, and a strategy for
@@ -194,7 +191,7 @@ public interface DataFormats {
   default Map<String, SourceData> parseDataSourcesInHierarchy(Path dataDir, Hierarchy hierarchy) {
     Map<String, SourceData> data = new HashMap<>();
 
-    hierarchy.descendants().stream()
+    hierarchy.allSources().stream()
         // TODO .parallel() but yaml is not threadsafe
         .map(Source::path)
         .forEach(source -> {

--- a/bin/src/io/github/alechenninger/monarch/Main.java
+++ b/bin/src/io/github/alechenninger/monarch/Main.java
@@ -40,7 +40,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -243,7 +242,7 @@ public class Main {
 
     // Sort by hierarchy depth if provided, else sort alphabetically
     Comparator<Change> changeComparator = hierarchy.map(h -> {
-      List<String> descendants = h.descendants().stream()
+      List<String> descendants = h.allSources().stream()
           .map(Source::path)
           .collect(Collectors.toList());
 

--- a/bin/test/io/github/alechenninger/monarch/ConfigSerializationTest.groovy
+++ b/bin/test/io/github/alechenninger/monarch/ConfigSerializationTest.groovy
@@ -43,7 +43,7 @@ mergeKeys:
 
     def options = new ApplyChangesOptionsFromSerializableConfig(config, FileSystems.default)
 
-    assert options.hierarchy().get().descendants().collect { it.path() } == ['foo', 'baz']
+    assert options.hierarchy().get().allSources().collect { it.path() } == ['foo', 'baz']
     assert options.mergeKeys() == ['bar'] as Set
   }
 }

--- a/lib/src/io/github/alechenninger/monarch/DynamicHierarchy.java
+++ b/lib/src/io/github/alechenninger/monarch/DynamicHierarchy.java
@@ -22,6 +22,7 @@ class DynamicHierarchy implements Hierarchy {
   private Map<String, Assignments> cachedPaths = new HashMap<>();
   private Map<Map.Entry<String, String>, Assignment> cachedAssignments = new HashMap<>();
   private Map<Assignments, Source> cachedSources = new HashMap<>();
+  private Map<SourceCacheKey, RenderedSource> cachedRenderedSources = new HashMap<>();
   private List<Source> all = null;
 
   private static final Logger log = LoggerFactory.getLogger(DynamicHierarchy.class);
@@ -94,13 +95,18 @@ class DynamicHierarchy implements Hierarchy {
       return Optional.ofNullable(cachedSources.get(assignments));
     }
 
-    RenderedNode target = null;
+    RenderedSource target = null;
 
     // First find target, if any.
-    for (DynamicNode node : nodes) {
+    for (int i = 0; i < nodes.size(); i++) {
+      DynamicNode node = nodes.get(i);
       if (assignments.assignsOnly(node.variables())) {
-        target = node.renderOne(assignments);
-        break;
+        try {
+          target = RenderedSource.newOrCached(node.renderOne(assignments), i, this);
+          break;
+        } catch (RenderedSource.UnreachableSourceException ignored) {
+          // TODO: error
+        }
       }
     }
 
@@ -113,46 +119,46 @@ class DynamicHierarchy implements Hierarchy {
     DynamicSource targetSource = null;
 
     // Build hierarchy from bottom up.
-    for (DynamicNode node : new ListReversed<>(nodes)) {
-      current = current == null ? new Level() : current.parent();
+//    for (DynamicNode node : new ListReversed<>(nodes)) {
+//      current = current == null ? new Level() : current.parent();
+//
+//      // Adding descendants of a target has different logic than ancestors.
+//      // While target source is null, it means we haven't found it yet, so we're still adding
+//      // descendants.
+//      if (targetSource == null) {
+//        List<RenderedNode> renders = node.render(assignments);
+//
+//        for (RenderedNode render : renders) {
+//          Assignments renderAssigns = inventory.assignAll(render.usedAssignments());
+//          if (assignments.isEmpty() || renderAssigns.containsAll(assignments)) {
+//            Optional<DynamicSource> maybeSource = current.addMember(render, renderAssigns);
+//            if (maybeSource.isPresent()) {
+//              DynamicSource source = maybeSource.get();
+//              if (source.path().equals(target.path())) {
+//                if (source.render.equals(target)) {
+//                  targetSource = source;
+//                } else {
+//                  log.error("Found source for assignments, but it is shadowed by a descendant " +
+//                          "with a duplicate path. Impossible to refer to desired position in " +
+//                          "hierarchy. Path was '{}'. Desired target for assignments {} was at " +
+//                          "node {}. Shadowed by same path at descendant {} from assignments {}.",
+//                      target.path(), assignments.toMap(), target.node(), source.node(),
+//                      source.assignments.toMap());
+//                }
+//              }
+//            }
+//          }
+//        }
+//      } else {
+//        if (assignments.assignsSupersetOf(node.variables())) {
+//          RenderedNode render = node.renderOne(assignments);
+//          current.addMember(render, assignments);
+//        }
+//      }
+//    }
 
-      // Adding descendants of a target has different logic than ancestors.
-      // While target source is null, it means we haven't found it yet, so we're still adding
-      // descendants.
-      if (targetSource == null) {
-        List<RenderedNode> renders = node.render(assignments);
-
-        for (RenderedNode render : renders) {
-          Assignments renderAssigns = inventory.assignAll(render.usedAssignments());
-          if (assignments.isEmpty() || renderAssigns.containsAll(assignments)) {
-            Optional<DynamicSource> maybeSource = current.addMember(render, renderAssigns);
-            if (maybeSource.isPresent()) {
-              DynamicSource source = maybeSource.get();
-              if (source.path().equals(target.path())) {
-                if (source.render.equals(target)) {
-                  targetSource = source;
-                } else {
-                  log.error("Found source for assignments, but it is shadowed by a descendant " +
-                          "with a duplicate path. Impossible to refer to desired position in " +
-                          "hierarchy. Path was '{}'. Desired target for assignments {} was at " +
-                          "node {}. Shadowed by same path at descendant {} from assignments {}.",
-                      target.path(), assignments.toMap(), target.node(), source.node(),
-                      source.assignments.toMap());
-                }
-              }
-            }
-          }
-        }
-      } else {
-        if (assignments.assignsSupersetOf(node.variables())) {
-          RenderedNode render = node.renderOne(assignments);
-          current.addMember(render, assignments);
-        }
-      }
-    }
-
-    cachedSources.put(assignments, targetSource);
-    return Optional.ofNullable(targetSource);
+    cachedSources.put(assignments, target);
+    return Optional.ofNullable(target);
   }
 
   @Override
@@ -212,55 +218,72 @@ class DynamicHierarchy implements Hierarchy {
         '}';
   }
 
-  class RenderedSource implements Source {
+  static class SourceCacheKey {
+    final RenderedNode render;
+    final int level;
+
+    public SourceCacheKey(RenderedNode render, int level) {
+      this.render = render;
+      this.level = level;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      SourceCacheKey sourceCacheKey = (SourceCacheKey) o;
+      return level == sourceCacheKey.level &&
+          Objects.equals(render, sourceCacheKey.render);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(render, level);
+    }
+  }
+
+  static class RenderedSource implements Source {
     private final RenderedNode render;
     private final Assignments assignments;
-    private Level level;
+    private final int level;
+    private final DynamicHierarchy hierarchy;
 
-    RenderedSource(RenderedNode render) {
-      this.render = render;
-      this.assignments = inventory.assignAll(render.usedAssignments());
+    private List<RenderedSource> lineage;
+    private List<RenderedSource> descendants;
 
-      Level current = new Level();
-      boolean descendants = true;
-
-      for (DynamicNode node : new ListReversed<>(nodes)) {
-        current = current == null ? new Level() : current.parent();
-
-        // Adding descendants of a target has different logic than ancestors.
-        // While target source is null, it means we haven't found it yet, so we're still adding
-        // descendants.
-        if (descendants) {
-          List<RenderedNode> nodeRenders = node.render(assignments);
-
-          for (RenderedNode nodeRender : nodeRenders) {
-            Assignments renderAssigns = inventory.assignAll(nodeRender.usedAssignments());
-            if (assignments.isEmpty() || renderAssigns.containsAll(assignments)) {
-              Optional<DynamicSource> maybeSource = current.addMember(nodeRender, renderAssigns);
-              if (maybeSource.isPresent()) {
-                DynamicSource source = maybeSource.get();
-                if (source.path().equals(path())) {
-                  if (source.render.equals(this.render)) {
-                    descendants = false;
-                    level = current;
-                  } else {
-                    log.error("Found source for assignments, but it is shadowed by a descendant " +
-                            "with a duplicate path. Impossible to refer to desired position in " +
-                            "hierarchy. Path was '{}'. Desired target for assignments {} was at " +
-                            "node {}. Shadowed by same path at descendant {} from assignments {}.",
-                        path(), assignments.toMap(), this.render.node(), source.node(),
-                        source.assignments.toMap());
-                  }
-                }
-              }
-            }
-          }
-        } else {
-          if (assignments.assignsSupersetOf(node.variables())) {
-            RenderedNode nodeRender = node.renderOne(assignments);
-            current.addMember(nodeRender, assignments);
-          }
+    static RenderedSource newOrCached(RenderedNode render, int level, DynamicHierarchy hierarchy) {
+      SourceCacheKey key = new SourceCacheKey(render, level);
+      if (hierarchy.cachedRenderedSources.containsKey(key)) {
+        RenderedSource source = hierarchy.cachedRenderedSources.get(key);
+        if (source == null) {
+          throw new UnreachableSourceException(render, level);
         }
+        return source;
+      }
+
+      try {
+        RenderedSource source = new RenderedSource(render, level, hierarchy);
+        hierarchy.cachedRenderedSources.put(key, source);
+        return source;
+      } catch (UnreachableSourceException e) {
+        hierarchy.cachedRenderedSources.put(key, null);
+        throw e;
+      }
+    }
+
+    private static class UnreachableSourceException extends RuntimeException {
+      public UnreachableSourceException(RenderedNode render, int level) {
+      }
+    }
+
+    private RenderedSource(RenderedNode render, int level, DynamicHierarchy hierarchy) {
+      this.render = render;
+      this.assignments = hierarchy.inventory.assignAll(render.usedAssignments());
+      this.level = level;
+      this.hierarchy = hierarchy;
+
+      if (descendants().stream().skip(1).anyMatch(d -> render.path().equals(d.path()))) {
+        throw new UnreachableSourceException(render, level);
       }
     }
 
@@ -271,27 +294,60 @@ class DynamicHierarchy implements Hierarchy {
 
     @Override
     public List<Source> lineage() {
-      List<Source> lineage = new ArrayList<>();
-      lineage.add(this);
-      DynamicSource ancestor = parent();
-      while (ancestor != null) {
-        lineage.add(ancestor);
-        ancestor = ancestor.parent();
+      if (lineage == null) {
+        lineage = new ArrayList<>();
+        lineage.add(this);
+
+        for (int parentLevel = level - 1; parentLevel >= 0; parentLevel--) {
+          DynamicNode node = hierarchy.nodes.get(parentLevel);
+          if (assignments.assignsSupersetOf(node.variables())) {
+            RenderedNode parentRender = node.renderOne(assignments);
+            if (lineage == null) {
+              lineage = new ArrayList<>();
+            }
+            try {
+              lineage.add(RenderedSource.newOrCached(parentRender, parentLevel, hierarchy));
+            } catch (UnreachableSourceException ignored) {
+              // TODO: warn
+            }
+          }
+        }
       }
-      return lineage;
+
+      return Collections.unmodifiableList(lineage);
     }
 
     @Override
     public List<Source> descendants() {
-      return level.descendants()
-          .stream()
-          .flatMap(l -> l.members().stream())
-          .collect(Collectors.toList());
+      if (descendants == null) {
+        descendants = new ArrayList<>();
+        descendants.add(this);
+
+        for (int childLevel = level + 1; childLevel < hierarchy.nodes.size(); childLevel++) {
+          List<RenderedNode> childRenders = hierarchy.nodes.get(childLevel).render(assignments);
+
+          for (RenderedNode childRender : childRenders) {
+            Assignments childAssigns = hierarchy.inventory.assignAll(childRender.usedAssignments());
+            if (assignments.isEmpty() || childAssigns.containsAll(assignments)) {
+              if (descendants == null ) {
+                descendants = new ArrayList<>(childRenders.size());
+              }
+              try {
+                descendants.add(RenderedSource.newOrCached(childRender, childLevel, hierarchy));
+              } catch (UnreachableSourceException ignored) {
+                // TODO: warn
+              }
+            }
+          }
+        }
+      }
+
+      return Collections.unmodifiableList(descendants);
     }
 
     @Override
     public boolean isTargetedBy(SourceSpec spec) {
-      return spec.findSource(DynamicHierarchy.this)
+      return spec.findSource(hierarchy)
           .map(found -> found.path().equals(path()))
           .orElse(false);
     }
@@ -299,22 +355,9 @@ class DynamicHierarchy implements Hierarchy {
     @Override
     public String toString() {
       return "RenderedSource{" +
-          "render=" + render +
-          ", level=" + level +
+          "node=" + render.node() +
+          ", path=" + render.path() +
           '}';
-    }
-
-    private DynamicSource parent() {
-      for (Level ancestorLevel : level.ancestors()) {
-        for (DynamicSource parent : ancestorLevel.parent()) {
-          // This will only ever have one?
-//          if (assignments.containsAll(parent.assignments)) {
-            return parent;
-//          }
-        }
-      }
-
-      return null;
     }
   }
 

--- a/lib/src/io/github/alechenninger/monarch/DynamicNode.java
+++ b/lib/src/io/github/alechenninger/monarch/DynamicNode.java
@@ -57,11 +57,14 @@ public interface DynamicNode {
     private final DynamicNode node;
     private final String path;
     private final Set<Assignment> usedAssignments;
+    private final int hash;
 
     public RenderedNode(String path, Set<Assignment> usedAssignments, DynamicNode node) {
       this.path = Objects.requireNonNull(path, "path");
       this.usedAssignments = Objects.requireNonNull(usedAssignments, "usedAssignments");
       this.node = Objects.requireNonNull(node, "node");
+
+      hash = Objects.hash(node, path, usedAssignments);
     }
 
     public String path() {
@@ -97,7 +100,7 @@ public interface DynamicNode {
 
     @Override
     public int hashCode() {
-      return Objects.hash(node, path, usedAssignments);
+      return hash;
     }
   }
 }

--- a/lib/src/io/github/alechenninger/monarch/Hierarchy.java
+++ b/lib/src/io/github/alechenninger/monarch/Hierarchy.java
@@ -58,5 +58,5 @@ public interface Hierarchy {
 
   Optional<Source> sourceFor(Assignments assignments);
 
-  List<Source> descendants();
+  List<Source> allSources();
 }

--- a/lib/src/io/github/alechenninger/monarch/InterpolatedDynamicNode.java
+++ b/lib/src/io/github/alechenninger/monarch/InterpolatedDynamicNode.java
@@ -38,6 +38,7 @@ public class InterpolatedDynamicNode implements DynamicNode {
   private final Optional<String> escapeCharacter;
 
   private final List<String> variableNames;
+  private final int hash;
 
   public InterpolatedDynamicNode(String expression) {
     this(expression, "%{", "}", Optional.of("\\"));
@@ -58,6 +59,9 @@ public class InterpolatedDynamicNode implements DynamicNode {
     paramCapture.interpolate(expression, null);
 
     this.variableNames = Collections.unmodifiableList(variableNames);
+
+    hash = Objects.hash(
+        expression, variableOpening, variableClosing, escapeCharacter, variableNames);
   }
 
   @Override
@@ -116,7 +120,6 @@ public class InterpolatedDynamicNode implements DynamicNode {
 
   @Override
   public int hashCode() {
-    return Objects.hash(expression, variableOpening, variableClosing, escapeCharacter,
-        variableNames);
+    return hash;
   }
 }

--- a/lib/src/io/github/alechenninger/monarch/StaticHierarchy.java
+++ b/lib/src/io/github/alechenninger/monarch/StaticHierarchy.java
@@ -66,7 +66,7 @@ class StaticHierarchy implements Hierarchy {
         "identifying a source via variables.");
   }
 
-  public List<Source> descendants() {
+  public List<Source> allSources() {
     return DescendantsIterator.asStream(rootNodes)
         .map(StaticSource::new)
         .collect(Collectors.toList());

--- a/lib/test/DynamicHierarchyTest.groovy
+++ b/lib/test/DynamicHierarchyTest.groovy
@@ -1,9 +1,7 @@
 import io.github.alechenninger.monarch.Assignable
 import io.github.alechenninger.monarch.Hierarchy
 import io.github.alechenninger.monarch.Inventory
-import io.github.alechenninger.monarch.Source
 import io.github.alechenninger.monarch.SourceSpec
-import org.junit.Ignore
 import org.junit.Test
 import org.yaml.snakeyaml.Yaml
 
@@ -41,7 +39,7 @@ inventory:
 
   @Test
   void shouldCalculateDescendantsFromPotentialValues() {
-    assert hierarchy.descendants()*.path() == [
+    assert hierarchy.allSources()*.path() == [
         "common",
         "rhel",
         "environment/qa",

--- a/lib/test/DynamicHierarchyTest.groovy
+++ b/lib/test/DynamicHierarchyTest.groovy
@@ -1,6 +1,7 @@
 import io.github.alechenninger.monarch.Assignable
 import io.github.alechenninger.monarch.Hierarchy
 import io.github.alechenninger.monarch.Inventory
+import io.github.alechenninger.monarch.Source
 import io.github.alechenninger.monarch.SourceSpec
 import org.junit.Ignore
 import org.junit.Test
@@ -9,6 +10,111 @@ import org.yaml.snakeyaml.Yaml
 class DynamicHierarchyTest {
   def yaml = new Yaml()
   def hierarchy = Hierarchy.fromStringListOrMap(yaml.load('''
+sources:
+  - common
+  - "%{os}"
+  - environment/%{environment}
+  - teams/%{team}
+  - teams/%{team}/%{environment}
+  - teams/%{team}/%{environment}/%{app}
+  - nodes/%{hostname}
+inventory:
+  hostname:
+    - foo.com:
+        team: teamA
+        environment: prod
+        os: rhel
+    - bar.com
+  team:
+  - teamA:
+      app: store
+  - teamB
+  environment:
+  - qa
+  - prod
+  app:
+  - store
+  - blog
+  os:
+  - rhel
+'''))
+
+  @Test
+  void shouldCalculateDescendantsFromPotentialValues() {
+    assert hierarchy.descendants()*.path() == [
+        "common",
+        "rhel",
+        "environment/qa",
+        "environment/prod",
+        "teams/teamA",
+        "teams/teamB",
+        "teams/teamA/qa",
+        "teams/teamA/prod",
+        "teams/teamB/qa",
+        "teams/teamB/prod",
+        "teams/teamA/qa/store",
+        "teams/teamA/prod/store",
+        // Since teamA implies app: store, there are no /team/teamA/*/blog descendants
+        "teams/teamB/qa/store",
+        "teams/teamB/qa/blog",
+        "teams/teamB/prod/store",
+        "teams/teamB/prod/blog",
+        "nodes/foo.com",
+        "nodes/bar.com",
+    ]
+  }
+
+  @Test
+  void shouldCalculateAncestorsByExactSource() {
+    assert hierarchy.sourceFor("teams/teamA/qa").get().lineage()*.path() == [
+        "teams/teamA/qa",
+        "teams/teamA",
+        "environment/qa",
+        "common",
+    ]
+  }
+
+  @Test
+  void shouldNotReturnASourceForUnsatisfiableVariableCombination() {
+    assert hierarchy.sourceFor(["team": "teamA", "environment": "qa", "os": "rhel"]) ==
+        Optional.empty()
+  }
+
+  @Test
+  void shouldCalculateAncestorsByCompleteVariables() {
+    assert hierarchy.sourceFor(["team": "teamA", "environment": "qa"]).get()
+        .lineage()*.path() == [
+        "teams/teamA/qa",
+        "teams/teamA",
+        "environment/qa",
+        "common",
+    ]
+  }
+
+  @Test
+  // TODO: Not sure if this should include dynamic source with only one assignable value
+  // Question of: is assignables expected to be comprehensive WRT when a variable may be potentially
+  // absent or not? I'm thinking if it's not absent, then you should supply the variable.
+  void shouldNotIncludeSourcesInAncestryWithAbsentVariables() {
+    assert hierarchy.sourceFor(["hostname": "bar.com"]).get()
+        .lineage()*.path() == ["nodes/bar.com", "common"]
+  }
+
+  @Test
+  void shouldCreateNewHierarchiesByExactSource() {
+    assert hierarchy.sourceFor("teams/teamB/prod").get()
+        .descendants()*.path() == [
+        "teams/teamB/prod",
+        "teams/teamB/prod/store",
+        "teams/teamB/prod/blog",
+    ]
+  }
+
+  @Test
+  // We could consider instead returning two Sources, one for each environment variable.
+  // But this gets complicated actually (weird edge cases), so for now the algorithm is simple.
+  void shouldNotReturnSourceIfNoOneSourceHasMatchingVariables() {
+    def hierarchy = Hierarchy.fromStringListOrMap(yaml.load('''
 sources:
   - common
   - "%{os}"
@@ -37,83 +143,12 @@ inventory:
   - rhel
 '''))
 
-  @Test
-  void shouldCalculateDescendantsFromPotentialValues() {
-    assert hierarchy.descendants().collect { it.path() } == [
-        "common",
-        "rhel",
-        "environment/qa",
-        "environment/prod",
-        "teams/teamA/qa",
-        "teams/teamA/prod",
-        "teams/teamB/qa",
-        "teams/teamB/prod",
-        "teams/teamA/qa/store",
-        "teams/teamA/prod/store",
-        // Since teamA implies app: store, there are no /team/teamA/*/blog descendants
-        "teams/teamB/qa/store",
-        "teams/teamB/qa/blog",
-        "teams/teamB/prod/store",
-        "teams/teamB/prod/blog",
-        "nodes/foo.com",
-        "nodes/bar.com",
-    ]
-  }
-
-  @Test
-  void shouldCalculateAncestorsByExactSource() {
-    assert hierarchy.sourceFor("teams/teamA/qa").get().lineage().collect { it.path() } == [
-        "teams/teamA/qa",
-        "environment/qa",
-        "common",
-    ]
-  }
-
-  @Test
-  void shouldNotReturnASourceForUnsatisfiableVariableCombination() {
-    assert hierarchy.sourceFor(["team": "teamA", "environment": "qa", "os": "rhel"]) ==
-        Optional.empty()
-  }
-
-  @Test
-  void shouldCalculateAncestorsByCompleteVariables() {
-    assert hierarchy.sourceFor(["team": "teamA", "environment": "qa"]).get()
-        .lineage().collect { it.path() } == [
-        "teams/teamA/qa",
-        "environment/qa",
-        "common",
-    ]
-  }
-
-  @Test
-  // TODO: Not sure if this should include dynamic source with only one assignable value
-  // Question of: is assignables expected to be comprehensive WRT when a variable may be potentially
-  // absent or not? I'm thinking if it's not absent, then you should supply the variable.
-  void shouldNotIncludeSourcesInAncestryWithAbsentVariables() {
-    assert hierarchy.sourceFor(["hostname": "bar.com"]).get()
-        .lineage().collect { it.path() } == ["nodes/bar.com", "common"]
-  }
-
-  @Test
-  void shouldCreateNewHierarchiesByExactSource() {
-    assert hierarchy.sourceFor("teams/teamB/prod").get()
-        .descendants().collect { it.path() } == [
-        "teams/teamB/prod",
-        "teams/teamB/prod/store",
-        "teams/teamB/prod/blog",
-    ]
-  }
-
-  @Test
-  // We could consider instead returning two Sources, one for each environment variable.
-  // But this gets complicated actually (weird edge cases), so for now the algorithm is simple.
-  void shouldNotReturnSourceIfNoOneSourceHasMatchingVariables() {
     assert hierarchy.sourceFor(["team": "teamA"]) == Optional.empty()
   }
 
   @Test
   void shouldCreateNewHierarchiesByCompleteVariables() {
-    assert hierarchy.sourceFor(["environment": "qa"]).get().descendants().collect { it.path() } == [
+    assert hierarchy.sourceFor(["environment": "qa"]).get().descendants()*.path() == [
         "environment/qa",
         "teams/teamA/qa",
         "teams/teamB/qa",
@@ -156,15 +191,16 @@ inventory:
     ]))
 
     assert hierarchy.sourceFor(["bar": "baz"]).get()
-        .descendants().collect { it.path() } == ["baz", "bar/baz"]
+        .descendants()*.path() == ["baz", "bar/baz"]
   }
 
   @Test
   void shouldUseImpliedValuesForLineage() {
-    assert hierarchy.sourceFor(['hostname': 'foo.com']).get().lineage().collect { it.path() } == [
+    assert hierarchy.sourceFor(['hostname': 'foo.com']).get().lineage()*.path() == [
         "nodes/foo.com",
         "teams/teamA/prod/store",
         "teams/teamA/prod",
+        "teams/teamA",
         "environment/prod",
         "rhel",
         "common",
@@ -173,7 +209,7 @@ inventory:
 
   @Test
   void shouldUseImpliedValuesForDescendants() {
-    assert hierarchy.sourceFor(['environment': 'prod']).get().descendants().collect { it.path() } == [
+    assert hierarchy.sourceFor(['environment': 'prod']).get().descendants()*.path() == [
         "environment/prod",
         "teams/teamA/prod",
         "teams/teamB/prod",
@@ -210,7 +246,7 @@ potentials:
   - blog
 '''))
 
-    assert hierarchy.sourceFor(['environment': 'prod', 'team': 'teamB']).get().descendants().collect { it.path() } == [
+    assert hierarchy.sourceFor(['environment': 'prod', 'team': 'teamB']).get().descendants()*.path() == [
         "teams/teamB/prod",
         "teams/teamB/prod/store",
         "teams/teamB/prod/blog",
@@ -251,7 +287,7 @@ potentials:
   - rhel
 '''))
 
-    assert hierarchy.sourceFor(['app': 'blog']).get().descendants().collect { it.path() } == [
+    assert hierarchy.sourceFor(['app': 'blog']).get().descendants()*.path() == [
         "app/blog",
         "teams/teamB/qa/blog",
         "teams/teamB/prod/blog",
@@ -385,7 +421,8 @@ potentials:
   }
 
   @Test
-  void ancestorsDescendantsShouldBeConsistentWithChildLineage() {
+  // TODO: Not sure if this actually tests this
+  void ancestorsDescendantsShouldBeRelativeToAncestor() {
     def hierarchy = Hierarchy.fromStringListOrMap(yaml.load('''
 sources:
   - top
@@ -406,6 +443,18 @@ potentials:
     def cBar = hierarchy.sourceFor(['c': 'bar']).get()
 
     assert cBar.lineage().get(2).descendants()*.path() == ['top', 'foo', 'bar/foo']
+  }
+
+  @Test
+  void descendantsAncestorsShouldBeRelativeToDescendant() {
+    def prod = hierarchy.sourceFor(['environment': 'prod']).get()
+    def environmentUnderTeam = prod.descendants()[1]
+    assert environmentUnderTeam.lineage()*.path() == [
+        'teams/teamA/prod',
+        'teams/teamA',
+        'environment/prod',
+        'common'
+    ]
   }
 
   @Test

--- a/lib/test/StaticHierarchyTest.groovy
+++ b/lib/test/StaticHierarchyTest.groovy
@@ -58,6 +58,6 @@ b:
   - b2
 '''))
 
-    assert ['a', 'b', 'a1', 'a2', 'b1', 'b2'] == hierarchy.descendants().collect { it.path() }
+    assert ['a', 'b', 'a1', 'a2', 'b1', 'b2'] == hierarchy.allSources().collect { it.path() }
   }
 }


### PR DESCRIPTION
/cc @snehagunta

Prior to this, when you asked for a source (for ex. when targeting one), we built the rendered hierarchy of reified paths and each source in that hierarchy existed as a part of the same hierarchy.

This meant if you had something like this:

```yaml
hierarchy:
- top
- environment/%{environment}
- team/%{team}
- team/%{team}/%{environment}
inventory:
  environment:
    - foo
  team:
    - A
    - B
```

And you targeted environment/foo, you would get these sources in a hierarchy:

- top
- environment/foo (target)
- team/A/foo
- team/B/foo

If you navigate to team/A/foo, and asked what its lineage was, it would say `[team/A/foo, environment/foo, top]`, because it was all apart of the same, rendered-once hierarchy.

The issue is that when it comes to inheriting values, we _know_ that team/A/foo inherits from team/A, always. So, if we have a change targeting team/A, it should apply to team/A/foo: this is among sources that touch team=A.

This PR changes sources to calculate their own lineage and descendants, which reflects how a sources values are actually inherited and what sources it inherits from.