### PR TITLE
Avoid changing existing whitespace outside of managed yaml blocks

### DIFF
--- a/bin/src/io/github/alechenninger/monarch/yaml/YamlDataFormat.java
+++ b/bin/src/io/github/alechenninger/monarch/yaml/YamlDataFormat.java
@@ -18,7 +18,6 @@
 
 package io.github.alechenninger.monarch.yaml;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.MapDifference;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -32,14 +31,12 @@ import io.github.alechenninger.monarch.yaml.YamlConfiguration.Isolate;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
-import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -50,7 +47,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.SortedMap;
 import java.util.TreeMap;
-import java.util.stream.Collectors;
 
 public class YamlDataFormat implements DataFormat {
   private final Yaml yaml;

--- a/bin/test/io/github/alechenninger/monarch/YamlDataFormatTest.groovy
+++ b/bin/test/io/github/alechenninger/monarch/YamlDataFormatTest.groovy
@@ -196,8 +196,26 @@ three: 3"""
       def update = new ByteArrayOutputStream()
       parser.parseData(new ByteArrayInputStream(source.bytes))
           .writeUpdate([
-          'test': 12,
-          'three': 3,
+              'test': 12,
+              'three': 3,
+      ], update)
+
+      Assert.assertEquals(source.toString(), update.toString())
+    }
+
+    @Test
+    void maintainesExistingLackOfNewlineAtEndOfFileEvenIfNothingOutsideOfManagedBlock() {
+      def out = new ByteArrayOutputStream()
+      parser.newSourceData().writeUpdate([
+          'test': 12
+      ], out)
+
+      def source = out.toString().trim()
+
+      def update = new ByteArrayOutputStream()
+      parser.parseData(new ByteArrayInputStream(source.bytes))
+          .writeUpdate([
+              'test': 12,
       ], update)
 
       Assert.assertEquals(source.toString(), update.toString())


### PR DESCRIPTION
Previously, monarch was enforcing some consistency: empty lines around managed blocks, and newline at end of files. But this can add a lot of noise to diffs if existing sources are missing newlines or have other whitespace alterations, causing confusion and discouraging applying changes broadly. This PR takes good care not to muck with ANYTHING outside of the managed sections.