### PR TITLE
Include all possible ancestors in lineage

### DIFF
--- a/bin/src/io/github/alechenninger/monarch/apply/ApplyChangesService.java
+++ b/bin/src/io/github/alechenninger/monarch/apply/ApplyChangesService.java
@@ -63,6 +63,7 @@ public class ApplyChangesService {
       checkChangeIsApplicable(hierarchy, change);
     }
 
+    // TODO: levelFor?
     Targetable target = targetSpec.map(spec -> Targetable.of(
         hierarchy.sourceFor(spec).orElseThrow(() -> new IllegalArgumentException(
             "No source found in hierarchy which satisfies: " + targetSpec))))

--- a/lib/src/io/github/alechenninger/monarch/Assignments.java
+++ b/lib/src/io/github/alechenninger/monarch/Assignments.java
@@ -220,27 +220,26 @@ public class Assignments implements Iterable<Assignment> {
    * Returns true if at least the provided variables are all assigned.
    */
   public boolean assignsSupersetOf(List<String> variables) {
-    Assignments assignments = new Assignments(inventory);
     for (String variable : variables) {
       if (!isAssigned(variable)) {
         return false;
       }
-      assignments.add(forVariable(variable));
     }
-    return containsAll(assignments);
+
+    return true;
   }
 
   /**
-   * Returns true if variables contains a superset of all of the assigned variables.
-   * @param variables
-   * @return
+   *
    */
   public boolean assignsSubsetOf(List<String> variables) {
-    Assignments assignments = new Assignments(inventory);
     for (String variable : variables) {
-      assignments.add(forVariable(variable));
+      if (isAssigned(variable)) {
+        return true;
+      }
     }
-    return assignments.containsAll(this);
+
+    return false;
   }
 
   public boolean isEmpty() {

--- a/lib/src/io/github/alechenninger/monarch/Collect.java
+++ b/lib/src/io/github/alechenninger/monarch/Collect.java
@@ -20,16 +20,28 @@ package io.github.alechenninger.monarch;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 abstract class Collect {
-  public static <T> Collector<? super T, ?, Optional<T>> maxOneResultOrThrow(Supplier
-      <RuntimeException> throwing) {
+  public static <T> Collector<? super T, ?, Optional<T>> maxOneResultOrThrow(
+      Supplier<RuntimeException> throwing) {
     return Collectors.collectingAndThen(Collectors.toList(), (List<T> list) -> {
       if (list.size() > 1) {
         throw throwing.get();
+      }
+
+      return list.isEmpty() ? Optional.empty() : Optional.of(list.get(0));
+    });
+  }
+
+  public static <T> Collector<? super T, ?, Optional<T>> maxOneResultOrThrowResult(
+      Function<List<T>, RuntimeException> throwing) {
+    return Collectors.collectingAndThen(Collectors.toList(), (List<T> list) -> {
+      if (list.size() > 1) {
+        throw throwing.apply(list);
       }
 
       return list.isEmpty() ? Optional.empty() : Optional.of(list.get(0));

--- a/lib/src/io/github/alechenninger/monarch/DataLookup.java
+++ b/lib/src/io/github/alechenninger/monarch/DataLookup.java
@@ -22,9 +22,11 @@ import java.util.List;
 import java.util.Optional;
 
 public interface DataLookup {
+  // TODO: lookup may return multiple values depending on assignments for ancestor
   Optional<Object> lookup(String key);
   List<SourceToValue> sourcesOf(String key);
   List<SourceToValue> sourcesOf(String key, Object value);
+  // TODO: multiple values may be inherited for same key depending on other assignments
   boolean isValueInherited(String key, Object value);
 
   final class SourceToValue {

--- a/lib/src/io/github/alechenninger/monarch/DataLookup.java
+++ b/lib/src/io/github/alechenninger/monarch/DataLookup.java
@@ -23,9 +23,9 @@ import java.util.Optional;
 
 public interface DataLookup {
   // TODO: lookup may return multiple values depending on assignments for ancestor
-  Optional<Object> lookup(String key);
-  List<SourceToValue> sourcesOf(String key);
-  List<SourceToValue> sourcesOf(String key, Object value);
+  List<Object> lookup(String key);
+  List<List<SourceToValue>> sourcesOf(String key);
+  List<List<SourceToValue>> sourcesOf(String key, Object value);
   // TODO: multiple values may be inherited for same key depending on other assignments
   boolean isValueInherited(String key, Object value);
 

--- a/lib/src/io/github/alechenninger/monarch/DataLookupFromMap.java
+++ b/lib/src/io/github/alechenninger/monarch/DataLookupFromMap.java
@@ -131,7 +131,7 @@ public class DataLookupFromMap implements DataLookup {
   }
 
   private List<String> sourceAncestry() {
-    return source.lineage().stream().map(Source::path).collect(Collectors.toList());
+    return source.lineage().stream().flatMap(l -> l.sources().stream()).map(Source::path).collect(Collectors.toList());
   }
 
   private Map<String, Object> getDataBySource(String source) {

--- a/lib/src/io/github/alechenninger/monarch/DataLookupFromMap.java
+++ b/lib/src/io/github/alechenninger/monarch/DataLookupFromMap.java
@@ -43,84 +43,114 @@ public class DataLookupFromMap implements DataLookup {
   }
 
   @Override
-  public Optional<Object> lookup(String key) {
+  public List<Object> lookup(String key) {
+    List<Object> values = new ArrayList<>();
+
     if (mergeKeys.contains(key)) {
-      Merger merger = null;
+      for (List<Source> line : sourceAncestries()) {
+        Merger mergerForLine = null;
 
-      for (String ancestor : sourceAncestry()) {
+        for (Source ancestor : line) {
+          Map<String, Object> ancestorData = getDataBySource(ancestor);
+
+          if (ancestorData.containsKey(key)) {
+            if (mergerForLine == null) {
+              mergerForLine = Merger.startingWith(ancestorData.get(key));
+            } else {
+              mergerForLine.merge(ancestorData.get(key));
+            }
+          }
+        }
+
+        if (mergerForLine != null) {
+          values.add(mergerForLine.getMerged());
+        }
+      }
+
+      return values;
+    }
+
+    for (List<Source> lines : sourceAncestries()) {
+      for (Source ancestor : lines) {
         Map<String, Object> ancestorData = getDataBySource(ancestor);
-
         if (ancestorData.containsKey(key)) {
-          if (merger == null) {
-            merger = Merger.startingWith(ancestorData.get(key));
+          values.add(ancestorData.get(key));
+          break; // next line...
+        }
+      }
+    }
+
+    return values;
+  }
+
+  @Override
+  public List<List<SourceToValue>> sourcesOf(String key) {
+    List<List<SourceToValue>> byLineage = new ArrayList<>();
+
+    for (List<Source> lineage : sourceAncestries()) {
+      List<SourceToValue> sources = new ArrayList<>();
+
+      for (Source ancestor : lineage) {
+        Map<String, Object> ancestorData = getDataBySource(ancestor);
+        if (ancestorData.containsKey(key)) {
+          sources.add(new SourceToValue(ancestor.path(), ancestorData.get(key)));
+        }
+      }
+
+      byLineage.add(sources);
+    }
+
+    return byLineage;
+  }
+
+  @Override
+  public List<List<SourceToValue>> sourcesOf(String key, Object value) {
+    List<List<SourceToValue>> byLineage = new ArrayList<>();
+
+    for (List<Source> lineage : sourceAncestries()) {
+      List<SourceToValue> sources = new ArrayList<>();
+
+      for (Source ancestor : lineage) {
+        Map<String, Object> ancestorData = getDataBySource(ancestor);
+        if (ancestorData.containsKey(key)) {
+          Object ancestorValue = ancestorData.get(key);
+
+          if (mergeKeys.contains(key)) {
+            Merger merger = Merger.startingWith(ancestorValue);
+            if (merger.contains(value)) {
+              sources.add(new SourceToValue(ancestor.path(), ancestorValue));
+            }
           } else {
-            merger.merge(ancestorData.get(key));
+            if (Objects.equals(ancestorValue, value)) {
+              sources.add(new SourceToValue(ancestor.path(), ancestorValue));
+            }
           }
         }
       }
 
-      return Optional.ofNullable(merger).map(Merger::getMerged);
+      byLineage.add(sources);
     }
 
-    for (String ancestor : sourceAncestry()) {
-      Map<String, Object> ancestorData = getDataBySource(ancestor);
-      if (ancestorData.containsKey(key)) {
-        return Optional.of(ancestorData.get(key));
-      }
-    }
-
-    return Optional.empty();
-  }
-
-  @Override
-  public List<SourceToValue> sourcesOf(String key) {
-    List<SourceToValue> sources = new ArrayList<>();
-
-    for (String ancestor : sourceAncestry()) {
-      Map<String, Object> ancestorData = getDataBySource(ancestor);
-      if (ancestorData.containsKey(key)) {
-        sources.add(new SourceToValue(ancestor, ancestorData.get(key)));
-      }
-    }
-
-    return sources;
-  }
-
-  @Override
-  public List<SourceToValue> sourcesOf(String key, Object value) {
-    List<SourceToValue> sources = new ArrayList<>();
-
-    for (String ancestor : sourceAncestry()) {
-      Map<String, Object> ancestorData = getDataBySource(ancestor);
-      if (ancestorData.containsKey(key)) {
-        Object ancestorValue = ancestorData.get(key);
-
-        if (mergeKeys.contains(key)) {
-          Merger merger = Merger.startingWith(ancestorValue);
-          if (merger.contains(value)) {
-            sources.add(new SourceToValue(ancestor, ancestorValue));
-          }
-        } else {
-          if (Objects.equals(ancestorValue, value)) {
-            sources.add(new SourceToValue(ancestor, ancestorValue));
-          }
-        }
-      }
-    }
-
-    return sources;
+    return byLineage;
   }
 
   @Override
   public boolean isValueInherited(String key, Object value) {
-    List<SourceToValue> sources = sourcesOf(key, value);
-    int sourcesCount = sources.size();
+    List<List<SourceToValue>> lines = sourcesOf(key, value);
 
-    if (sourcesCount == 1 && sources.get(0).source().equals(path)) {
-      return false;
+    for (List<SourceToValue> sources : lines) {
+      int sourcesCount = sources.size();
+
+      if (sourcesCount == 1 && sources.get(0).source().equals(path)) {
+        return false;
+      }
+
+      if (sourcesCount == 0) {
+        return false;
+      }
     }
 
-    return sourcesCount > 0;
+    return true;
   }
 
   @Override
@@ -130,11 +160,15 @@ public class DataLookupFromMap implements DataLookup {
         '}';
   }
 
-  private List<String> sourceAncestry() {
-    return source.lineage().stream().flatMap(l -> l.sources().stream()).map(Source::path).collect(Collectors.toList());
+  private List<Level> sourceAncestry() {
+    return source.lineage();
   }
 
-  private Map<String, Object> getDataBySource(String source) {
-    return Optional.ofNullable(data.get(source)).orElse(Collections.emptyMap());
+  private List<List<Source>> sourceAncestries() {
+    return source.lineage().get(0).lineages();
+  }
+
+  private Map<String, Object> getDataBySource(Source source) {
+    return Optional.ofNullable(data.get(source.path())).orElse(Collections.emptyMap());
   }
 }

--- a/lib/src/io/github/alechenninger/monarch/DescendantsIterator.java
+++ b/lib/src/io/github/alechenninger/monarch/DescendantsIterator.java
@@ -1,0 +1,60 @@
+/*
+ * monarch - A tool for managing hierarchical data.
+ * Copyright (C) 2017 Alec Henninger
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.github.alechenninger.monarch;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+class DescendantsIterator<T extends HasDescendants<T>> implements Iterator<T> {
+  private Queue<T> currentLevel = new LinkedList<>();
+
+  DescendantsIterator(Collection<T> nodes) {
+    currentLevel.addAll(nodes);
+  }
+
+  static <T extends HasDescendants<T>> Stream<T> asStream(Collection<T> nodes) {
+    Iterable<T> descendantsIterable = () -> new DescendantsIterator<>(nodes);
+    return StreamSupport.stream(descendantsIterable.spliterator(), false);
+  }
+
+  @Override
+  public boolean hasNext() {
+    return !currentLevel.isEmpty();
+  }
+
+  @Override
+  public T next() {
+    T next = currentLevel.remove();
+
+    Collection<T> nextChildren = next.children();
+    if (!nextChildren.isEmpty()) {
+      currentLevel.addAll(nextChildren);
+    }
+
+    return next;
+  }
+}
+
+interface HasDescendants<T extends HasDescendants<T>> {
+  Collection<T> children();
+}

--- a/lib/src/io/github/alechenninger/monarch/DynamicHierarchy.java
+++ b/lib/src/io/github/alechenninger/monarch/DynamicHierarchy.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -45,27 +46,7 @@ class DynamicHierarchy implements Hierarchy {
 
   @Override
   public Optional<Source> sourceFor(String source) {
-    if (!cachedPaths.containsKey(source)) {
-
-      List<Assignments> satisfyingVars = nodes.stream()
-          .flatMap(node -> node.assignmentsFor(source, inventory, Assignments.none(inventory))
-              .map(Stream::of).orElse(Stream.empty()))
-          .collect(Collectors.toList());
-
-      if (satisfyingVars.isEmpty()) {
-        cachedPaths.put(source, null);
-      }
-
-      Assignments allVariables = new Assignments(inventory);
-      // TODO: Instead, we can do this in loop over nodes
-      for (Assignments assignments : satisfyingVars) {
-        allVariables = allVariables.with(assignments);
-      }
-
-      cachedPaths.put(source, allVariables);
-    }
-
-    return Optional.ofNullable(cachedPaths.get(source)).flatMap(this::sourceFor);
+    return assignmentsFor(source).flatMap(this::sourceFor);
   }
 
   @Override
@@ -123,6 +104,59 @@ class DynamicHierarchy implements Hierarchy {
 
     cachedSources.put(assignments, target);
     return Optional.of(target);
+  }
+
+  @Override
+  public Optional<Level> levelFor(String source) {
+    return ListReversed.stream(nodes)
+        .flatMap(node -> node
+            .assignmentsFor(source, Assignments.none(inventory))
+            .map(Stream::of).orElse(Stream.empty()))
+        .findFirst()
+        .flatMap(used -> levelFor(used.stream()
+            .collect(Collectors.toMap(a -> a.variable().name(), Assignment::value))
+        ));
+  }
+
+  @Override
+  public Optional<Level> levelFor(Map<String, String> variables) {
+    RenderedLevel target = null;
+
+    // First find target, if any.
+    for (int i = 0; i < nodes.size(); i++) {
+      DynamicNode node = nodes.get(i);
+      if (node.variables().containsAll(variables.keySet())) {
+        try {
+          target = levelFor(inventory.assignAll(variables), i, false);
+          break;
+        } catch (UnreachableSourceException ignored) {
+          // Get next best level...
+        }
+      }
+    }
+
+    return Optional.ofNullable(target);
+  }
+
+  public Optional<Level> levelFor(Assignments assignments) {
+    RenderedLevel target = null;
+
+    // First find target, if any.
+    for (int i = 0; i < nodes.size(); i++) {
+      DynamicNode node = nodes.get(i);
+      List<String> variables = node.variables();
+
+      if (variables.containsAll(assignments.toMap().keySet())) {
+        try {
+          target = levelFor(assignments, i, false);
+          break;
+        } catch (UnreachableSourceException ignored) {
+          // Get next best level...
+        }
+      }
+    }
+
+    return Optional.ofNullable(target);
   }
 
   @Override
@@ -227,12 +261,61 @@ class DynamicHierarchy implements Hierarchy {
     }
   }
 
+  private RenderedLevel levelFor(Assignments assignments, int index, boolean renderOne) {
+    DynamicNode node = nodes.get(index);
+    List<RenderedNode> rendered = node.render(assignments);
+    if (!renderOne) {
+      List<RenderedSource> sources = new ArrayList<>(rendered.size());
+      for (RenderedNode render : rendered) {
+        try {
+          sources.add(sourceFor(render, index));
+        } catch (UnreachableSourceException ignored) {
+          // Continue...
+        }
+      }
+      boolean skippable = sources.isEmpty();
+      return new RenderedLevel(sources, skippable);
+    } else {
+      if (rendered.size() == 1) {
+        try {
+          return new RenderedLevel(sourceFor(rendered.get(0), index));
+        } catch (UnreachableSourceException e) {
+          throw e; // TODO?
+        }
+      } else {
+        return new RenderedLevel(Collections.emptyList(), true);
+      }
+    }
+  }
+
+  private Optional<Assignments> assignmentsFor(String source) {
+    if (!cachedPaths.containsKey(source)) {
+      List<Set<Assignment>> satisfyingVars = nodes.stream()
+          .flatMap(node -> node.assignmentsFor(source, Assignments.none(inventory))
+              .map(Stream::of).orElse(Stream.empty()))
+          .collect(Collectors.toList());
+
+      if (satisfyingVars.isEmpty()) {
+        cachedPaths.put(source, null);
+      } else {
+        Assignments allVariables = new Assignments(inventory);
+        // TODO: Instead, we can do this in loop over nodes
+        for (Set<Assignment> assignments : satisfyingVars) {
+          allVariables = allVariables.with(assignments);
+        }
+        cachedPaths.put(source, allVariables);
+      }
+    }
+
+    return Optional.ofNullable(cachedPaths.get(source));
+  }
+
   private class RenderedSource implements Source {
     private final RenderedNode render;
     private final Assignments assignments;
     private final int level;
 
-    private List<RenderedSource> lineage;
+    private List<RenderedLevel> lineage;
     private List<RenderedSource> descendants;
 
     private RenderedSource(RenderedNode render, int level) {
@@ -264,24 +347,52 @@ class DynamicHierarchy implements Hierarchy {
     }
 
     @Override
-    public List<Source> lineage() {
+    public List<Level> lineage() {
       if (lineage == null) {
         lineage = new ArrayList<>(level + 1 /* == how many in lineage + me */);
-        lineage.add(this);
+        lineage.add(new RenderedLevel(this));
+
+        /*
+        Each source above this could be figured out from what values are possible considering:
+        1. Current assignments for this source
+        2. Possible assignments for all nodes below this source
+
+        #2 Could be figured out from:
+        - Consider the variables used but unassigned below this source
+        - Limit possible values for lineage to all of possible values in descendants
+        - Unused variable == no possible values, however an unused variable can still be
+          implied.
+
+        This is where it gets tricky because we have to assume that all possible values are
+        comprehensive. In other words, it requires the inventory has absolutely everything it in,
+        otherwise we could deduce something that really isn't true, it's just the user assumed they
+        didn't have to tell us about every little thing.
+
+        For now, we only treat the bottom source as special. We really know that nothing can be
+        below that, so no reason to consider possibilities other than what is defined.
+        */
+        boolean isBottomSource = level == nodes.size() - 1;
 
         for (int parentLevel = level - 1; parentLevel >= 0; parentLevel--) {
-          DynamicNode node = nodes.get(parentLevel);
-          if (assignments.assignsSupersetOf(node.variables())) {
-            RenderedNode parentRender = node.renderOne(assignments);
-            if (lineage == null) {
-              lineage = new ArrayList<>();
-            }
-            try {
-              lineage.add(sourceFor(parentRender, parentLevel));
-            } catch (UnreachableSourceException ignored) {
-              // Fall through
-            }
+          try {
+            RenderedLevel level = levelFor(assignments, parentLevel, isBottomSource);
+            if (level.isEmpty()) continue;
+            lineage.add(level);
+          } catch (UnreachableSourceException ignored) {
+            // Fall through
           }
+
+//          if (assignments.assignsSupersetOf(node.variables())) {
+//            RenderedNode parentRender = node.renderOne(assignments);
+//            if (lineage == null) {
+//              lineage = new ArrayList<>();
+//            }
+//            try {
+//              lineage.add(sourceFor(parentRender, parentLevel));
+//            } catch (UnreachableSourceException ignored) {
+//              // Fall through
+//            }
+//          }
         }
       }
 
@@ -302,8 +413,9 @@ class DynamicHierarchy implements Hierarchy {
           List<RenderedNode> childRenders = nodes.get(childLevel).render(assignments);
 
           for (RenderedNode childRender : childRenders) {
-            Assignments childAssigns = inventory.assignAll(childRender.usedAssignments());
-            if (assignments.isEmpty() || childAssigns.containsAll(assignments)) {
+            Assignments usedByChild = inventory.assignAll(childRender.usedAssignments());
+            // TODO: isEmpty is redundant I think; any collection contains the empty collection
+            if (assignments.isEmpty() || usedByChild.containsAll(assignments)) {
               if (descendants == null ) {
                 descendants = new ArrayList<>(childRenders.size());
               }
@@ -348,6 +460,59 @@ class DynamicHierarchy implements Hierarchy {
     @Override
     public int hashCode() {
       return Objects.hash(render, level);
+    }
+  }
+
+  private class RenderedLevel implements Level {
+    private final List<RenderedSource> sources;
+    private final boolean skippable;
+
+    public RenderedLevel(RenderedSource source) {
+      this.skippable = false;
+      this.sources = Collections.singletonList(source);
+    }
+
+    public RenderedLevel(List<RenderedSource> sources, boolean skippable) {
+      this.sources = sources;
+      this.skippable = skippable;
+    }
+
+    @Override
+    public List<Source> sources() {
+      return Collections.unmodifiableList(sources);
+    }
+
+    @Override
+    public boolean skippable() {
+      return skippable;
+    }
+
+    @Override
+    public boolean isTargetedBy(SourceSpec spec) {
+      return spec.findLevel(DynamicHierarchy.this)
+          .map(Level::sources)
+          .map(s -> sources.stream().map(Source::path).collect(Collectors.toSet())
+              .equals(s.stream().map(Source::path).collect(Collectors.toSet())))
+          .orElse(false);
+    }
+
+    @Override
+    public String toString() {
+      return "{" + sources + ", skippable=" + skippable +  '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      RenderedLevel that = (RenderedLevel) o;
+      return skippable == that.skippable &&
+          Objects.equals(sources, that.sources);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(sources, skippable);
     }
   }
 

--- a/lib/src/io/github/alechenninger/monarch/DynamicNode.java
+++ b/lib/src/io/github/alechenninger/monarch/DynamicNode.java
@@ -18,6 +18,7 @@
 
 package io.github.alechenninger.monarch;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -43,14 +44,12 @@ public interface DynamicNode {
 
   List<RenderedNode> render(Assignments assignments);
 
-  default Optional<Assignments> assignmentsFor(String source,
-      Inventory potentials, Assignments variables) {
-    return render(variables).stream()
+  default Optional<Set<Assignment>> assignmentsFor(String source, Assignments variables) {
+    Optional<RenderedNode> node = render(variables).stream()
         .filter(s -> s.path().equals(source))
-        .map(RenderedNode::usedAssignments)
-        // TODO validate only one found?
-        .findFirst()
-        .map(potentials::assignAll);
+        .collect(Collect.maxOneResultOrThrowResult(r -> new IllegalArgumentException(
+            "Expected at most one render that matched source but got: " + r)));
+    return node.map(RenderedNode::usedAssignments);
   }
 
   final class RenderedNode {

--- a/lib/src/io/github/alechenninger/monarch/Hierarchy.java
+++ b/lib/src/io/github/alechenninger/monarch/Hierarchy.java
@@ -58,5 +58,12 @@ public interface Hierarchy {
 
   Optional<Source> sourceFor(Assignments assignments);
 
+  Optional<Level> levelFor(String source);
+
+  Optional<Level> levelFor(Map<String, String> variables);
+
+  Optional<Level> levelFor(Assignments assignments);
+
   List<Source> allSources();
+
 }

--- a/lib/src/io/github/alechenninger/monarch/Level.java
+++ b/lib/src/io/github/alechenninger/monarch/Level.java
@@ -19,18 +19,19 @@
 package io.github.alechenninger.monarch;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
-public abstract class Sources {
-  public static List<String> pathsOf(List<Source> sources) {
-    return sources.stream()
-        .map(Source::path)
-        .collect(Collectors.toList());
+public interface Level {
+  List<Source> sources();
+  // TODO: Do we need this?
+  boolean skippable();
+  boolean isTargetedBy(SourceSpec spec);
+  default boolean isEmpty() {
+    return sources().isEmpty();
   }
-
-  public static List<String> pathsOfLineage(List<Level> lineage) {
-    return pathsOf(lineage.stream()
-        .flatMap(l -> l.sources().stream())
-        .collect(Collectors.toList()));
+  default int size() {
+    return sources().size();
+  }
+  default Source get(int index) {
+    return sources().get(index);
   }
 }

--- a/lib/src/io/github/alechenninger/monarch/Level.java
+++ b/lib/src/io/github/alechenninger/monarch/Level.java
@@ -24,6 +24,8 @@ public interface Level {
   List<Source> sources();
   // TODO: Do we need this?
   boolean skippable();
+  List<List<Source>> lineages();
+  List<Source> descendants();
   boolean isTargetedBy(SourceSpec spec);
   default boolean isEmpty() {
     return sources().isEmpty();
@@ -35,3 +37,18 @@ public interface Level {
     return sources().get(index);
   }
 }
+
+/*
+
+a    b     c    d
+|\   |     |    |
+|  \ |     |    |
+e    f     |    g
+ \   | \   |   /
+   \ |   \ | /
+     h     i
+
+
+
+
+ */

--- a/lib/src/io/github/alechenninger/monarch/MapMerger.java
+++ b/lib/src/io/github/alechenninger/monarch/MapMerger.java
@@ -35,6 +35,7 @@ public class MapMerger implements Merger {
       throw new IllegalArgumentException("Can only merge a map with other maps!");
     }
 
+    // TODO: Shouldn't this not override existing overlapping keys?
     merged.putAll((Map) toMerge);
   }
 

--- a/lib/src/io/github/alechenninger/monarch/Monarch.java
+++ b/lib/src/io/github/alechenninger/monarch/Monarch.java
@@ -63,6 +63,11 @@ public class Monarch {
     return generateSources(hierarchy.allSources(), changes, data, mergeKeys);
   }
 
+  public Map<String, Map<String, Object>> generateSources(Level level,
+      Iterable<Change> changes, Map<String, Map<String, Object>> data, Set<String> mergeKeys) {
+    return generateSources(level.descendants(), changes, data, mergeKeys);
+  }
+
   private Map<String, Map<String, Object>> generateSources(List<Source> sources,
       Iterable<Change> changes, Map<String, Map<String, Object>> data, Set<String> mergeKeys) {
     Map<String, Map<String, Object>> result = copyMapAndValues(data);
@@ -120,7 +125,7 @@ public class Monarch {
 
       Change change = maybeChange.get();
 
-      log.debug("Applying change for ancestor '{}' (targeted by {}) to '{}'.",
+      log.debug("Applying change for ancestor level '{}' (targeted by {}) to '{}'.",
           ancestors, change.sourceSpec(), target.path());
 
       for (Map.Entry<String, Object> setEntry : change.set().entrySet()) {

--- a/lib/src/io/github/alechenninger/monarch/Monarch.java
+++ b/lib/src/io/github/alechenninger/monarch/Monarch.java
@@ -86,7 +86,7 @@ public class Monarch {
    */
   private Map<String, Object> generateSingleSource(Source target, Iterable<Change> changes,
       Map<String, Map<String, Object>> data, Set<String> mergeKeys) {
-    List<Source> lineage = target.lineage();
+    List<Level> lineage = target.lineage();
 
     DataLookup targetLookup = new DataLookupFromMap(data, target, mergeKeys);
 
@@ -96,11 +96,23 @@ public class Monarch {
         : new HashMap<>(sourceData);
 
     if (log.isDebugEnabled()) {
-      log.debug("Looking for changes applicable to lineage: {}", Sources.pathsOf(lineage));
+      log.debug("Looking for changes applicable to lineage: {}", Sources.pathsOfLineage(lineage));
     }
 
-    for (Source ancestor : new ListReversed<>(lineage)) {
-      Optional<Change> maybeChange = findChangeForSource(ancestor, changes);
+    // TODO: lineage would be Level of various Sources?
+    // TODO: Or we would have multiple lineages for each permutation
+    for (Level ancestors : new ListReversed<>(lineage)) {
+      /*
+      find change for level?
+      what if multiple changes?
+      what if change only patches part of level? is it applicable to this descendant?
+      i dont think so
+      we would want to warn if those values weren't inherited? or perhaps more accurately that there
+      is no way within the targeted variables to apply the change without conflicting with the
+      changes
+      it could do it by going lower, to individual nodes in our hierarchy's case.
+       */
+      Optional<Change> maybeChange = findChangeForLevel(ancestors, changes);
 
       if (!maybeChange.isPresent()) {
         continue;
@@ -109,13 +121,16 @@ public class Monarch {
       Change change = maybeChange.get();
 
       log.debug("Applying change for ancestor '{}' (targeted by {}) to '{}'.",
-          ancestor.path(), change.sourceSpec(), target.path());
+          ancestors, change.sourceSpec(), target.path());
 
       for (Map.Entry<String, Object> setEntry : change.set().entrySet()) {
         String setKey = setEntry.getKey();
         Object setValue = setEntry.getValue();
 
         if (target.isNotTargetedBy(change.sourceSpec())) {
+          /*
+          if multiple different values inherited, then its not inherited
+           */
           if (targetLookup.isValueInherited(setKey, setValue)) {
             log.debug("Desired key:value is inherited above '{}': <{}: {}>",
                 target.path(), setKey, setValue);
@@ -165,12 +180,12 @@ public class Monarch {
     return resultSourceData;
   }
 
-  private Optional<Change> findChangeForSource(Source source, Iterable<Change> changes) {
+  private Optional<Change> findChangeForLevel(Level level, Iterable<Change> changes) {
     return StreamSupport.stream(changes.spliterator(), false)
-        .filter(c -> source.isTargetedBy(c.sourceSpec()))
-        .collect(Collect.maxOneResultOrThrow(() -> new IllegalArgumentException(
-            "Expected at most one change with matching source in list of changes, but got: " +
-                changes)));
+        .filter(c -> level.isTargetedBy(c.sourceSpec()))
+        .collect(Collect.maxOneResultOrThrowResult(c -> new IllegalArgumentException(
+            "Expected at most one change for level " + level + " in list of changes, but got: " +
+                c)));
   }
 
   private static Map<String, Map<String, Object>> copyMapAndValues(

--- a/lib/src/io/github/alechenninger/monarch/Source.java
+++ b/lib/src/io/github/alechenninger/monarch/Source.java
@@ -8,7 +8,7 @@ public interface Source {
   /**
    * Returns this source and its ancestors in a single line up to a furthest root.
    */
-  List<Source> lineage();
+  List<Level> lineage();
 
   /**
    * Returns all of the node names in order of <em>nearest to furthest</em>, including the root

--- a/lib/src/io/github/alechenninger/monarch/SourceSpec.java
+++ b/lib/src/io/github/alechenninger/monarch/SourceSpec.java
@@ -15,6 +15,8 @@ public interface SourceSpec {
 
   Optional<Source> findSource(Hierarchy hierarchy);
 
+  Optional<Level> findLevel(Hierarchy hierarchy);
+
   Object toStringOrMap();
 
   @SuppressWarnings("unchecked")
@@ -97,6 +99,11 @@ public interface SourceSpec {
     }
 
     @Override
+    public Optional<Level> findLevel(Hierarchy hierarchy) {
+      return hierarchy.levelFor(variables);
+    }
+
+    @Override
     public Object toStringOrMap() {
       return variables;
     }
@@ -137,6 +144,12 @@ public interface SourceSpec {
     @Override
     public Optional<Source> findSource(Hierarchy hierarchy) {
       return hierarchy.sourceFor(path);
+    }
+
+    @Override
+    public Optional<Level> findLevel(Hierarchy hierarchy) {
+//      throw new UnsupportedOperationException("TODO");
+      return hierarchy.levelFor(path);
     }
 
     @Override

--- a/lib/src/io/github/alechenninger/monarch/StaticHierarchy.java
+++ b/lib/src/io/github/alechenninger/monarch/StaticHierarchy.java
@@ -66,6 +66,23 @@ class StaticHierarchy implements Hierarchy {
         "identifying a source via variables.");
   }
 
+  @Override
+  public Optional<Level> levelFor(String source) {
+    return sourceFor(source).map(StaticLevel::new);
+  }
+
+  @Override
+  public Optional<Level> levelFor(Map<String, String> variables) {
+    throw new UnsupportedOperationException("Statically defined hierarchies do not support " +
+        "identifying a level via variables.");
+  }
+
+  @Override
+  public Optional<Level> levelFor(Assignments assignments) {
+    throw new UnsupportedOperationException("Statically defined hierarchies do not support " +
+        "identifying a level via variables.");
+  }
+
   public List<Source> allSources() {
     return DescendantsIterator.asStream(rootNodes)
         .map(StaticSource::new)
@@ -148,9 +165,10 @@ class StaticHierarchy implements Hierarchy {
     }
 
     @Override
-    public List<Source> lineage() {
+    public List<Level> lineage() {
       return AncestorsIterator.asStream(source)
           .map(StaticSource::new)
+          .map(StaticLevel::new)
           .collect(Collectors.toList());
     }
 
@@ -186,6 +204,34 @@ class StaticHierarchy implements Hierarchy {
     @Override
     public String toString() {
       return "Source(" + path() + ")";
+    }
+  }
+
+  private static class StaticLevel implements Level {
+    private final Source source;
+
+    private StaticLevel(Source source) {
+      this.source = source;
+    }
+
+    @Override
+    public List<Source> sources() {
+      return Collections.singletonList(source);
+    }
+
+    @Override
+    public boolean skippable() {
+      return false;
+    }
+
+    @Override
+    public boolean isTargetedBy(SourceSpec spec) {
+      return source.isTargetedBy(spec);
+    }
+
+    @Override
+    public String toString() {
+      return source.toString();
     }
   }
 

--- a/lib/test/AssignmentsTest.groovy
+++ b/lib/test/AssignmentsTest.groovy
@@ -24,6 +24,40 @@ import org.junit.runner.RunWith
 
 @RunWith(Enclosed.class)
 class AssignmentsTest {
+  static class AssignsSubset {
+    def inventory = Inventory.from([
+        'dessert': [Assignable.of('cookie', ['drink': 'milk']), Assignable.of('ice cream')],
+        'drink'  : [Assignable.of('milk', ['garnish': 'straw']), Assignable.of('soda')],
+        'garnish': [Assignable.of('straw'), Assignable.of('cherry')],
+    ])
+
+    @Test
+    void whenAssignsAllVariables() {
+      assert inventory.assignAll(['dessert': 'ice cream', 'drink': 'soda', 'garnish': 'straw'])
+          .assignsSubsetOf(['dessert', 'drink', 'garnish'])
+    }
+
+    @Test
+    void notWhenVariablesAreEmpty() {
+      assert !inventory.assignAll(['dessert': 'cookie']).assignsSubsetOf([])
+    }
+
+    @Test
+    void notWhenAllVariablesAreUnassigned() {
+      assert !inventory.assignAll(['garnish': 'straw']).assignsSubsetOf(['drink'])
+    }
+
+    @Test
+    void whenAssignsSomeVariablesButNotOthers() {
+      assert inventory.assignAll(['garnish': 'straw']).assignsSubsetOf(['garnish', 'drink'])
+    }
+
+    @Test
+    void whenAssignSomeVariablesImplicitly() {
+      assert inventory.assignAll(['drink': 'milk']).assignsSubsetOf(['garnish', 'dessert'])
+    }
+  }
+
   static class ShouldConflictWhenAssignment {
     @Test(expected = IllegalArgumentException.class)
     void impliesTransitivelyAConflictWithItsImplication() {


### PR DESCRIPTION
Instead of only including ancestors we *knew* we inherited from, include
all possible ancestors that we *can* inherit from, depending on other
assignments.

Fixes #100 